### PR TITLE
Fix strings being edited when switching fixed specs

### DIFF
--- a/src/modules/toggleFixedSpec.ts
+++ b/src/modules/toggleFixedSpec.ts
@@ -40,18 +40,9 @@ function toggleJS(editor: vscode.TextEditor, currentLine: vscode.TextLine){
 }
 
 function toggleRSpec(editor: vscode.TextEditor, currentLine: vscode.TextLine) {
-  let newLine: string;
-  let fixedRegex = new RegExp(`f(${rspecIdentifiers.join('|')}) (\'|\"|\{|do)`);
-
-  if(fixedRegex.test(currentLine.text)) {
-    newLine = currentLine.text.replace('fit', 'it');
-    newLine = newLine.replace('fdescribe', 'describe');
-    newLine = newLine.replace('fcontext', 'context');
-  } else {
-    newLine = currentLine.text.replace('it', 'fit');
-    newLine = newLine.replace('describe', 'fdescribe');
-    newLine = newLine.replace('context', 'fcontext');
-  }
+  const newLine = currentLine.text.replace(/\b(f?it|f?describe|f?context)\b/, match => {
+    return match.charAt(0) === 'f' ? match.slice(1) : 'f' + match;
+  });
 
   return editor.edit(editBuilder => {
     editBuilder.replace(currentLine.range, newLine);

--- a/src/test/fixtures/rails_app/spec/ruby_file_spec.rb
+++ b/src/test/fixtures/rails_app/spec/ruby_file_spec.rb
@@ -10,5 +10,8 @@ RSpec.describe RubyFile do
 
     it do
     end
+
+    context 'with the value' do
+    end
   end
 end

--- a/src/test/suite/modules/toggleFixed.test.ts
+++ b/src/test/suite/modules/toggleFixed.test.ts
@@ -75,5 +75,10 @@ suite('toggleFixedSpec Test Suite', () => {
 
     await toggleFixedSpec();
     assert.strictEqual(document.lineAt(10).text, "    it do");
+
+    await vscode.commands.executeCommand('cursorMove', {to: 'down', by: 'line', value: 3});
+
+    await toggleFixedSpec();
+    assert.strictEqual(document.lineAt(13).text, "    fcontext 'with the value' do");
   });
 });


### PR DESCRIPTION
There is a small bug in the part of pinning and unpinning a test.
When we have a 'describe' for example, the content of this describe string is changed when there is an it inside it, as in the example below.

![Screen Shot 2023-09-21 at 22 20 08](https://github.com/DouglasRochaT/spec-utils/assets/57448772/5ae0d3ba-5ee9-4205-aa85-14556de4f879)
![Screen Shot 2023-09-21 at 22 20 22](https://github.com/DouglasRochaT/spec-utils/assets/57448772/45a7bc6b-c0ba-42f0-a4ef-aa93097245e1)

In the example we can see that the 'with' within the description has been changed to 'wfith'.

With this PR I seek to solve this problem, searching only for the first appearance of a 'describe', 'context' or 'it' and changing it only.

I'm open to reviews.

I didn't change the tests because I don't know if it's necessary or not, but if you want to tell me what would be best to do, between changing the current test to deal with this or creating a test specifically testing for this bug not happening, just let me know